### PR TITLE
Update sha3.c

### DIFF
--- a/sha3.c
+++ b/sha3.c
@@ -65,6 +65,8 @@ void SHA3_Transform (SHA3_CTX *ctx)
   for (i=0; i<ctx->blklen/8; i++) {
     st[i] ^= p[i];
   }
+  // This upper code is not valid when blklen not divisble by 8. I.e SHA3_224
+  
   for (round = 0; round < ctx->rounds; round++) 
   {
     // Theta


### PR DESCRIPTION
A comment on SHA3_Transform; the initial XOR of the block with the state is made in a way incompatible with block lengths not divisible by 8.

(P.S. my example is not valid because SHA3_224 still has a block size multiple of 8)